### PR TITLE
Fixing dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
-  "name": "istio build-tools",
-  "image": "gcr.io/istio-testing/build-tools:master-0aa2afb4bac9a4fd1bfe50a929c077a643066b3a",
+  "name": "istio proxy build-tools",
+  "image": "gcr.io/istio-testing/build-tools-proxy:master-0aa2afb4bac9a4fd1bfe50a929c077a643066b3a",
   "privileged": true,
   "remoteEnv": {
     "USE_GKE_GCLOUD_AUTH_PLUGIN": "True",


### PR DESCRIPTION
Moving the proxy building container for vscode.

**What this PR does / why we need it**:
The devcontainer `image` field points to the container that is used for building `istio` and it does not have `bazel` installed in it. Fixing the `image` field should help to setup the vscode workspace properly.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
